### PR TITLE
Sort metrics family

### DIFF
--- a/merge_test.go
+++ b/merge_test.go
@@ -2,6 +2,7 @@ package promaggr_test
 
 import (
 	"bytes"
+	"sort"
 	"testing"
 
 	"github.com/d-kuro/promaggr"
@@ -36,6 +37,10 @@ func TestMergeMetricFamily(t *testing.T) {
 	}
 
 	out := bytes.Buffer{}
+
+	sort.Slice(mfs, func(i, j int) bool {
+		return mfs[i].GetName() < mfs[j].GetName()
+	})
 
 	for _, mf := range mfs {
 		if _, err := expfmt.MetricFamilyToText(&out, mf); err != nil {


### PR DESCRIPTION
```
=== CONT  TestMergeMetricFamily
    merge_test.go:58: MergeMetricFamily() mismatch (-want +got):
          strings.Join({
        +     "# HELP dummy_gauge_metric Dummy text.",
        +     "# TYPE dummy_gauge_metric gauge",
        +     `dummy_gauge_metric{cluster_name="foo"} 123.456`,
        +     `dummy_gauge_metric{cluster_name="bar"} 123.456`,
              "# HELP dummy_counter_metric Dummy text.",
              "# TYPE dummy_counter_metric counter",
              `dummy_counter_metric{cluster_name="foo"} 123456`,
              `dummy_counter_metric{cluster_name="bar"} 123456`,
        -     "# HELP dummy_gauge_metric Dummy text.",
        -     "# TYPE dummy_gauge_metric gauge",
        -     `dummy_gauge_metric{cluster_name="foo"} 123.456`,
        -     `dummy_gauge_metric{cluster_name="bar"} 123.456`,
              "",
          }, "\n")
--- FAIL: TestMergeMetricFamily (0.00s)
```